### PR TITLE
move docs to sidebase.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,8 @@ name: publish-sidebase-docs-on-merge-main
 trigger:
   event:
     - push
-  branch:
-    - main
+  # branch:
+  #   - main
   
 steps:
 - name: publish-sidebase-docs-on-merge-main
@@ -46,8 +46,8 @@ clone:
 trigger:
   event:
     - push
-  branch:
-    - main
+  # branch:
+  #   - main
 
 steps:
 - name: deploy

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,8 @@ name: publish-sidebase-docs-on-merge-main
 trigger:
   event:
     - push
-  # branch:
-  #   - main
+  branch:
+    - main
   
 steps:
 - name: publish-sidebase-docs-on-merge-main
@@ -46,8 +46,8 @@ clone:
 trigger:
   event:
     - push
-  # branch:
-  #   - main
+  branch:
+    - main
 
 steps:
 - name: deploy

--- a/kubernetes/helm/helmsman.yml
+++ b/kubernetes/helm/helmsman.yml
@@ -27,6 +27,7 @@ apps:
     protected: false
     priority: -1
     wait: true
+    timeout: 500
     helmFlags: [
       "--atomic",
     ]

--- a/kubernetes/helm/values-sidebase-docs.yml
+++ b/kubernetes/helm/values-sidebase-docs.yml
@@ -17,7 +17,7 @@ commitShortSHA: 123456
 service:
   type: LoadBalancer
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: v2.sidebase.io
+    external-dns.alpha.kubernetes.io/hostname: sidebase.io
   ports:
     http:
       port: 80


### PR DESCRIPTION
Closes N/A

Automatically deploys the `https://sidebase.io` now instead of the `v2` subdomain.

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
