### PR TITLE
docs: fix alert component in nuxt-prisma

### DIFF
--- a/content/4.nuxt-prisma/1.getting-started/3.quick-start.md
+++ b/content/4.nuxt-prisma/1.getting-started/3.quick-start.md
@@ -36,4 +36,6 @@ describe('test that involves the database', () => {
 })
 ```
 
-::alert{type="danger"} `resetDatabase` drops all data of the database that is currently configured via the environment variable `DATABASE_URL`, never run `resetDatabase` in production.::
+::alert{type="danger"}
+`resetDatabase` drops all data of the database that is currently configured via the environment variable `DATABASE_URL`, never run `resetDatabase` in production.
+::

--- a/content/4.nuxt-prisma/1.getting-started/3.quick-start.md
+++ b/content/4.nuxt-prisma/1.getting-started/3.quick-start.md
@@ -36,4 +36,4 @@ describe('test that involves the database', () => {
 })
 ```
 
-::alert{type="danger"}`resetDatabase` drops all data of the database that is currently configured via the environment variable `DATABASE_URL`, never run `resetDatabase` in production.::
+::alert{type="danger"} `resetDatabase` drops all data of the database that is currently configured via the environment variable `DATABASE_URL`, never run `resetDatabase` in production.::


### PR DESCRIPTION
Closes nothing

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable

Added whitespace after `::alert{type="danger"}`
Alert component wasn't being rendered because of no whitespace after `::alert{type="danger"}`:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/95541290/212644084-75159836-ac94-441e-a2ff-04c14d0e5617.png">