### PR TITLE
Use cluster docker builder in pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,9 @@ kind: pipeline
 type: docker
 name: publish-sidebase-docs-on-merge-main
 
+node:
+  docker: cluster
+
 trigger:
   event:
     - push

--- a/kubernetes/helm/values-sidebase-docs.yml
+++ b/kubernetes/helm/values-sidebase-docs.yml
@@ -27,8 +27,8 @@ service:
       value: "scaffoldWashere"
 
 podAutoscaler:
-  minReplicas: 1
-  maxReplicas: 1
+  minReplicas: 2
+  maxReplicas: 3
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
Closes N/A

Adds routing to the build-step to manually enforce to use the cluster docker-builder.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
