### PR TITLE
Remove `nuxt-prisma` from LP and modules navbar

### DIFF
--- a/components/docs/ModulesBar.vue
+++ b/components/docs/ModulesBar.vue
@@ -24,12 +24,6 @@ const props = defineProps({
           :current-page-id="currentPageId"
       />
       <ModulesBarLink
-          title="nuxt-prisma"
-          icon="heroicons-outline:circle-stack"
-          href="/nuxt-prisma"
-          :current-page-id="currentPageId"
-      />
-      <ModulesBarLink
           title="nuxt-parse"
           icon="heroicons-outline:clipboard-document-list"
           href="/nuxt-parse"

--- a/components/landing/ModulesSection.vue
+++ b/components/landing/ModulesSection.vue
@@ -3,7 +3,7 @@ import Module from "./Module.vue";
 </script>
 
 <template>
-  <div class="grid xl:grid-cols-4 gap-10">
+  <div class="grid xl:grid-cols-3 gap-10">
     <Module
       name="nuxt-auth"
       icon="heroicons-solid:lock-closed"
@@ -15,12 +15,6 @@ import Module from "./Module.vue";
         icon="heroicons-solid:squares-plus"
         link="/nuxt-session"
         description="Nuxt session middleware to get a persistent session per app user, e.g., to store data across multiple requests."
-    />
-    <Module
-        name="nuxt-prisma"
-        icon="heroicons-solid:circle-stack"
-        link="/nuxt-prisma/getting-started"
-        description="Open source Nuxt 3 layer that provides an Prisma ORM integration for Nuxt 3 applications. "
     />
     <Module
         name="nuxt-parse"


### PR DESCRIPTION
Contributes to https://github.com/sidebase/docs/pull/87

This PR is in preparation for the deprecation of `nuxt-prisma`. The docs will remain online, however ever reference to it has been removed. This includes:

- The modules section on the landing page
- The link in the modules sub navbar

When we merge this, do we want to add a bigger banner in the nuxt prisma docs to make sure no one misses it @BracketJohn? (this would have to be done inside https://github.com/sidebase/nuxt-prisma)