### PR TITLE
fix: fixed Cheviot stack link in 1.index.md

### DIFF
--- a/content/1.sidebase/1.welcome/1.index.md
+++ b/content/1.sidebase/1.welcome/1.index.md
@@ -15,7 +15,7 @@ The core of sidebase are [Nuxt 3](https://nuxt.com/) and [TypeScript](https://ww
 
 This approach is inspired by [remix.run](https://remix.run). With the provided stacks everything is configured and setup for you. You can focus on building a great app instead of spending time on setup. Currently, the following stacks are available:
 - [Merino](/sidebase/welcome/stacks#merino): A modular stack that let's you choose configuration and modules, e.g.: Want Prisma ORM or not? Want Authentication or not? ... Merino is ideal if you want fine-grained control
-- [Cheviot](/sidebase/welcome/stacks#merino): A batteries-included but less flexible stack where most decisions were made for you. Cheviot is ideal if you want to just get going with an opinionated stack that works
+- [Cheviot](/sidebase/welcome/stacks#cheviot): A batteries-included but less flexible stack where most decisions were made for you. Cheviot is ideal if you want to just get going with an opinionated stack that works
 
 To get started, run:
 ::code-group


### PR DESCRIPTION
Correct the link for the Cheviot stack, which previously linked to the Merino stack.

Closes # .

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
